### PR TITLE
Refactor instructions

### DIFF
--- a/base_bytecode_test.py
+++ b/base_bytecode_test.py
@@ -35,5 +35,7 @@ class BaseBytecodeTest(interpreter.Interpreter):
         (module, global_state) = self.setup_interp("temp.bc", argc, argv)
         self.module = module
         self.global_state = global_state
+        interpreter.Interpreter.interp_state.update(module=module, global_state=global_state)
+        interpreter.print_function = self.puts
         self.run(module.w_main_fun)
         return self.output

--- a/base_bytecode_test.py
+++ b/base_bytecode_test.py
@@ -1,8 +1,7 @@
 from state import State
-from type_wrapper import Integer, List, String, NumericValue
+from type_wrapper import NumericValue
 
 import interpreter
-import sys
 import subprocess
 
 class BaseBytecodeTest(interpreter.Interpreter):

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,10 +1,10 @@
 from __future__ import with_statement
 from rpython.rlib import jit
-from type_wrapper import String, Integer, Float, Ptr, List,\
-                         Value, NoValue, NumericValue, BasicBlock
+from type_wrapper import String, Integer, Ptr, Value, NoValue,\
+                         NumericValue, BasicBlock
 from llvm_objects import W_Module, W_BrInstruction, W_PhiInstruction,\
                          W_CallInstruction, W_ConditionalInstruction,\
-                         W_ICmpInstruction, W_SwitchInstruction
+                         W_SwitchInstruction
 from state import State
 from rpython.rtyper.lltypesystem import rffi, lltype
 
@@ -35,271 +35,106 @@ class InvalidFileException(Exception):
 class UnparsableBitcodeException(Exception):
     pass
 
-class Interpreter(object):
+def exit_not_implemented(name):
+    print "[ERROR]: Found unimplemented operation. Exiting."
+    raise NotImplementedError(name)
 
-    def __init__(self, module, global_state):
-        self.module = module
-        self.global_state = global_state
-        self.last_block = None
-        self.current_instruction = None
+def puts(string, args=[]):
+    ''' Prints (on separate lines) the given string and the arguments
+        specified. '''
 
-    @jit.unroll_safe
-    def _get_args(self, args):
-        ''' Returns a list of arguments. '''
-
-        arg_vals = []
+    print string
+    if args:
         for arg in args:
-            arg_vals.append(self.lookup_var(arg))
-        return arg_vals
+            assert isinstance(arg, NumericValue)
+            print arg.value
+        print "\n\n"
 
-    def exit_not_implemented(self, name):
-        print "[ERROR]: Found unimplemented operation. Exiting."
-        raise NotImplementedError(name)
+class InterpreterState(object):
 
-    def puts(self, string, args=[]):
-        print string
-        if args:
-            for arg in args:
-                assert isinstance(arg, NumericValue)
-                print arg.value
-            print "\n\n"
+    def __init__(self, module=None, frame=None, global_state=None, last_block=None):
+        self.module = module
+        self.current_frame = frame
+        self.global_state = global_state
+        self.last_block = last_block
 
-    def lookup_var(self, var):
-        ''' Returns the value of a variable. First checks locals, then globals. '''
+    def update(self, module=None, frame=None, global_state=None, last_block=None):
+        if module:
+            self.module = module
+        if frame:
+            self.current_frame = frame
+        if global_state:
+            self.global_state = global_state
+        if last_block:
+            self.last_block = last_block
+
+    def lookup_var(self, var, ignore_err=False):
+        ''' Returns the value of a variable. First checks if the Variable
+            is a Constant; if it is not an LLVM constant, the
+            local variable dictionary is checked, followed by the global
+            variable dictionary. '''
 
         if isinstance(var, llvm_objects.Constant):
             return var.content
-        elif self.frame.has_key(var.addr):
-            return self.frame.get_variable(var.addr)
+        elif self.current_frame.has_key(var.addr):
+            return self.current_frame.get_variable(var.addr)
         elif self.global_state.has_key(var.addr):
             return self.global_state.get_variable(var.addr)
-        else:
+        elif not ignore_err:
             print "[ERROR]: Unknown variable. Exiting."
-            raise NoSuchVariableException(rffi.charp2str(llwrap.LLVMPrintValueToString(var.l_value)))
-
-    @jit.unroll_safe
-    def get_phi_result(self, function, instruction):
-        ''' Returns the result of a given phi instruction. '''
-
-        assert isinstance(instruction, W_PhiInstruction)
-        for i in range(instruction.count_incoming):
-            w_block = instruction.incoming_block[i]
-            if w_block == self.last_block:
-                return self.lookup_var(instruction.incoming_value[i])
-
-    def get_switch_block(self, instruction, args):
-        ''' Returns the block a switch instruction branches to. '''
-
-        assert isinstance(instruction, W_SwitchInstruction)
-        cond = self.lookup_var(args[0])
-        assert isinstance(cond, Integer)
-        for i in range(2, len(args), 2):
-            switch_var = self.lookup_var(args[i])
-            assert isinstance(switch_var, Integer)
-            if cond.value == switch_var.value:
-                return BasicBlock(instruction.w_blocks[i / 2  - 1])
-        return BasicBlock(instruction.default_branch)
+            error_str = rffi.charp2str(llwrap.LLVMPrintValueToString(var.l_value))
+            raise NoSuchVariableException(error_str)
 
     def set_var(self, var, new_value):
         ''' Changes the value of an existing variable to the one specified. '''
 
         assert isinstance(new_value, Value)
         addr = rffi.cast(rffi.INT, var)
-        if self.frame.has_key(addr):
-            self.frame.set_variable(addr, new_value)
+        if self.current_frame.has_key(addr):
+            self.current_frame.set_variable(addr, new_value)
         elif self.global_state.has_key(addr):
             self.global_state.set_variable(addr, new_value)
         else:
             print "[ERROR]: Unknown variable. Exiting."
-            raise NoSuchVariableException(rffi.charp2str(llwrap.LLVMPrintValueToString(var)))
+            error_str = rffi.charp2str(llwrap.LLVMPrintValueToString(var))
+            raise NoSuchVariableException(error_str)
 
-    def has_function(self, function):
-        ''' Return true if the file being interpreted contains a given function,
-            false otherwise. '''
+class Interpreter(object):
 
-        if rffi.cast(rffi.INT, function) in self.functions:
-            return True
-        return False
+    interp_state = InterpreterState()
 
-    def eval_condition(self, predicate, val1, val2):
-        ''' Returns the wrapped boolean result of the comparison of the values of
-            the two arguments, according to an ICmp predicate. '''
-
-        assert isinstance(val1, Integer) and isinstance(val2, Integer)
-        if predicate == llwrap.LLVMIntSLT:
-            return Integer(val1.value < val2.value)
-        elif predicate == llwrap.LLVMIntSLE:
-            return Integer(val1.value <= val2.value)
-        elif predicate == llwrap.LLVMIntEQ:
-            return Integer(val1.value == val2.value)
-        elif predicate == llwrap.LLVMIntNE:
-            return Integer(val1.value != val2.value)
-        elif predicate == llwrap.LLVMIntSGT:
-            return Integer(val1.value > val2.value)
-        elif predicate == llwrap.LLVMIntSGE:
-            return Integer(val1.value >= val2.value)
-        else:
-            self.exit_not_implemented("Unknown ICmp predicate %d" % predicate)
+    def __init__(self, module, global_state):
+        self.module = module
+        self.global_state = global_state
+        self.current_instruction = None
+        Interpreter.interp_state.update(module=self.module,\
+                                        global_state=self.global_state)
 
     @jit.unroll_safe
-    def exec_operation(self, function, instruction):
-        opcode = instruction.opcode
-        args = instruction.operands
-        if opcode == llwrap.LLVMRet:
-            if len(args) == 0:
-                return NoValue()
-            else:
-                return self.lookup_var(args[0])
-        elif opcode == llwrap.LLVMAdd:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(x.value + y.value)
-        elif opcode == llwrap.LLVMFAdd:
-            x, y = self._get_args(args)
-            assert isinstance(x, Float) and isinstance(y, Float)
-            return Float(x.value + y.value)
-        elif opcode == llwrap.LLVMMul:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(x.value * y.value)
-        elif opcode == llwrap.LLVMFMul:
-            x, y = self._get_args(args)
-            assert isinstance(x, Float) and isinstance(y, Float)
-            return Float(x.value * y.value)
-        elif opcode == llwrap.LLVMSub:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(x.value - y.value)
-        elif opcode == llwrap.LLVMFSub:
-            x, y = self._get_args(args)
-            assert isinstance(x, Float) and isinstance(y, Float)
-            return Float(x.value - y.value)
-        elif opcode == llwrap.LLVMSDiv:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(x.value / y.value)
-        elif opcode == llwrap.LLVMFDiv:
-            x, y = self._get_args(args)
-            assert isinstance(x, Float) and isinstance(y, Float)
-            return Float(x.value / y.value)
-        elif opcode == llwrap.LLVMSRem:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(int(x.value) % int(y.value))
-        elif opcode == llwrap.LLVMAnd:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(int(x.value) & int(y.value))
-        elif opcode == llwrap.LLVMOr:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(int(x.value) | int(y.value))
-        elif opcode == llwrap.LLVMXor:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(int(x.value) ^ int(y.value))
-        elif opcode == llwrap.LLVMShl:
-            x, y = self._get_args(args)
-            assert isinstance(x, Integer) and isinstance(y, Integer)
-            return Integer(int(x.value) << int(y.value))
-        elif opcode == llwrap.LLVMCall:
-            assert isinstance(instruction, W_CallInstruction)
-            if self.module.has_function(args[-1].l_value):
-                for index in range(instruction.func_param_count):
-                    param = instruction.l_func_params[index]
-                    self.global_state.set_variable(param.addr,\
-                                                   self.lookup_var(args[index]))
-                interp_fun = Interpreter(self.module, self.global_state)
-                func = self.module.get_function(args[-1].l_value)
-                return interp_fun.run(func)
-            else:
-                string_format_ref = instruction.string_format_ref
-                str_var = self.lookup_var(string_format_ref)
-                assert isinstance(str_var, String)
-                string_format = str_var.value
-                fn_name = instruction.func_name
-                if fn_name == "printf" or fn_name == "puts":
-                    printf_args = []
-                    for i in range(1, len(args) - 1):
-                        var = self.lookup_var(args[i])
-                        printf_args.append(var)
-                    self.puts(string_format, printf_args)
-                else:
-                    self.exit_not_implemented(fn_name)
-        elif opcode == llwrap.LLVMAlloca:
-            return Ptr(lltype.scoped_alloc(rffi.VOIDP.TO, 1))
-        elif opcode == llwrap.LLVMStore:
-            # store arg[0] in arg[1]
-            var = self.lookup_var(args[0])
-            self.set_var(args[1].l_value, var)
-        elif opcode == llwrap.LLVMLoad:
-            return self.lookup_var(args[0])
-        elif opcode == llwrap.LLVMFPExt:
-            # extend a floating point value (eg float -> double)
-            var_val = self.lookup_var(args[0])
-            assert isinstance(var_val, Float)
-            return Float(var_val.value)
-        elif opcode == llwrap.LLVMZExt:
-            var_val = self.lookup_var(args[0])
-            assert isinstance(var_val, Integer)
-            return Integer(var_val.value)
-        elif opcode == llwrap.LLVMFPTrunc:
-            # truncate a floating point value (double -> float)
-            var_val = self.lookup_var(args[0])
-            assert isinstance(var_val, Float)
-            return Float(var_val.value)
-        elif opcode == llwrap.LLVMSIToFP:
-            # convert Signed to Floating Point
-            var_val = self.lookup_var(args[0])
-            assert isinstance(var_val, Integer)
-            return Float(float(var_val.value))
-        elif opcode == llwrap.LLVMBr:
-            # if the jump is conditional, it's necessary to find
-            # the block to jump to
-            if instruction.is_conditional():
-                assert isinstance(instruction, W_ConditionalInstruction)
-                cond = self.lookup_var(instruction.condition)
-                assert isinstance(cond, Integer)
-                if cond.value == True:
-                    return BasicBlock(instruction.w_bb_true)
-                else:
-                    return BasicBlock(instruction.w_bb_false)
-            else:
-                # unconditional jump
-                assert isinstance(instruction, W_BrInstruction)
-                return BasicBlock(instruction.w_bb_uncond)
-        elif opcode == llwrap.LLVMICmp:
-            val1 = self.lookup_var(args[0])
-            val2 = self.lookup_var(args[1])
-            assert isinstance(instruction, W_ICmpInstruction)
-            predicate = instruction.icmp_predicate
-            return self.eval_condition(predicate, val1, val2)
-        elif opcode == llwrap.LLVMPHI:
-            return self.get_phi_result(function, instruction)
-        elif opcode == llwrap.LLVMSelect:
-            cond = self.lookup_var(args[0])
-            assert isinstance(cond, Integer)
-            if cond.value != 0:
-                return self.lookup_var(args[1])
-            else:
-                return self.lookup_var(args[2])
-        elif opcode == llwrap.LLVMSwitch:
-            return self.get_switch_block(instruction, args)
-        else:
-            self.exit_not_implemented("Unknown opcode %d" % opcode)
-        return NoValue()
+    def _get_args(self, args):
+        ''' Returns a list of Values representing each Variable
+            in args. '''
+
+        arg_vals = []
+        for arg in args:
+            arg_vals.append(self.interp_state.lookup_var(arg, ignore_err=True))
+        return arg_vals
 
     def run(self, function):
+        ''' Runs each instruction of the given function and creates
+            a new stack frame for the local variables. '''
+
         self.frame = State()
         block = function.get_first_block()
+        Interpreter.interp_state.update(frame=self.frame, last_block=block)
         while block:
             jit_driver.jit_merge_point(function=function, block=block, self=self)
-            last_block_loc = self.last_block
             instruction = block.get_first_instruction()
             next_block = block.w_next_block
             while instruction:
                 self.current_instruction = instruction
-                result = self.exec_operation(function, instruction)
+                result = instruction.execute(self._get_args(instruction.operands))
+                Interpreter.interp_state.update(frame=self.frame)
                 if isinstance(result, BasicBlock):
                     next_block = result.value
                     break
@@ -309,37 +144,39 @@ class Interpreter(object):
                 # last instruction should be ret
                 if not instruction:
                     return result
-            self.last_block = block
+            self.interp_state.update(last_block=block)
             block = next_block
 
 def create_module(filename):
-    ''' Returns the module created with the contents of the given file
-        as a W_Module object. '''
+    ''' Returns the W_Module representing an LLVM module created with the
+        contents of the given file. '''
 
     module = llwrap.LLVMModuleCreateWithName("module")
     with lltype.scoped_alloc(rffi.CCHARPP.TO, 1) as out_message:
         with lltype.scoped_alloc(rffi.VOIDP.TO, 1) as mem_buff:
             with lltype.scoped_alloc(rffi.VOIDPP.TO, 1) as mem_buff_ptr:
                 mem_buff_ptr[0] = mem_buff
-                rc = llwrap.LLVMCreateMemoryBufferWithContentsOfFile(filename, mem_buff_ptr, out_message)
+                rc = llwrap.LLVMCreateMemoryBufferWithContentsOfFile(filename,
+                                                                     mem_buff_ptr,
+                                                                     out_message)
                 if rc != 0:
-                    print"[ERROR]: Cannot create memory buffer with contents of"\
-                         " %s: %s.\n" % (filename, rffi.charp2str(out_message[0]))
+                    print "[ERROR]: Cannot create memory buffer with contents of"\
+                          " %s: %s.\n" % (filename, rffi.charp2str(out_message[0]))
                     raise InvalidFileException(filename)
                 mem_buff = mem_buff_ptr[0]
-
             with lltype.scoped_alloc(rffi.VOIDPP.TO, 1) as module_ptr:
                 module_ptr[0] = module
                 rc = llwrap.LLVMParseBitcode(mem_buff, module_ptr, out_message)
                 if rc != 0:
-                    print "[ERROR]: Cannot parse %s: %s.\n" % (filename, rffi.charp2str(out_message[0]))
+                    print "[ERROR]: Cannot parse %s: %s.\n" % (filename,
+                                                               rffi.charp2str(out_message[0]))
                     raise UnparsableBitcodeException(filename)
                 module = module_ptr[0]
     return W_Module(module)
 
 def main(args):
     if len(args) < 2:
-        print"[ERROR]: Need an argument:\nUsage: ./llvmtest name.bc [C args]\n"
+        print"[ERROR]: Need an argument:\nUsage: ./interpreter-c name.bc [C args]\n"
         return 1
     module = create_module(args[1])
     main_argc = len(args) - 1
@@ -352,4 +189,3 @@ def main(args):
 
 if __name__ == '__main__':
    main(sys.argv)
-

--- a/interpreter.py
+++ b/interpreter.py
@@ -99,6 +99,10 @@ class InterpreterState(object):
             error_str = rffi.charp2str(llwrap.LLVMPrintValueToString(var))
             raise NoSuchVariableException(error_str)
 
+# the print function to use - can be changed to some other function
+# for testing purposes (to supress and save the output)
+print_function = puts
+
 class Interpreter(object):
 
     interp_state = InterpreterState()

--- a/llvm_objects.py
+++ b/llvm_objects.py
@@ -1,5 +1,4 @@
 from rpython.rlib import jit
-from state import State
 from type_wrapper import String, Integer, Float, Ptr, Value, List, NoValue,\
                          BasicBlock
 from rpython.rtyper.lltypesystem import rffi, lltype
@@ -395,7 +394,7 @@ class W_CallInstruction(W_BaseInstruction):
                 for i in range(1, len(self.operands) - 1):
                     var = Interpreter.interp_state.lookup_var(self.operands[i])
                     printf_args.append(var)
-                interpreter.puts(string_format, printf_args)
+                interpreter.print_function(string_format, printf_args)
             else:
                 interpreter.exit_not_implemented(self.func_name)
         return NoValue()

--- a/state.py
+++ b/state.py
@@ -1,5 +1,60 @@
 from type_wrapper import Integer, Value
 from rpython.rlib import jit
+from rpython.rtyper.lltypesystem import rffi
+
+import llvm_wrapper as llwrap
+
+class NoSuchVariableException(Exception):
+    pass
+
+class InterpreterState(object):
+
+    def __init__(self, module=None, frame=None, global_state=None, last_block=None):
+        self.update(module, frame, global_state, last_block)
+
+    def update(self, module=None, frame=None, global_state=None, last_block=None):
+        if module:
+            self.module = module
+        if frame:
+            self.current_frame = frame
+        if global_state:
+            self.global_state = global_state
+        if last_block:
+            self.last_block = last_block
+
+    def lookup_var(self, var, ignore_err=False):
+        ''' Returns the value of a variable. First checks if the Variable
+            is a Constant; if it is not an LLVM constant, the
+            local variable dictionary is checked, followed by the global
+            variable dictionary. Raises a NoSuchVariableException if the
+            variable is not found in the dictionary and ignore_err=False.
+            Returns None if the variable is not found and ignore_err=True.'''
+
+        from llvm_objects import Constant
+        if isinstance(var, Constant):
+            return var.content
+        elif self.current_frame.has_key(var.addr):
+            return self.current_frame.get_variable(var.addr)
+        elif self.global_state.has_key(var.addr):
+            return self.global_state.get_variable(var.addr)
+        elif not ignore_err:
+            print "[ERROR]: Unknown variable. Exiting."
+            error_str = rffi.charp2str(llwrap.LLVMPrintValueToString(var.l_value))
+            raise NoSuchVariableException(error_str)
+
+    def set_var(self, var, new_value):
+        ''' Changes the value of an existing variable to the one specified. '''
+
+        assert isinstance(new_value, Value)
+        addr = rffi.cast(rffi.INT, var)
+        if self.current_frame.has_key(addr):
+            self.current_frame.set_variable(addr, new_value)
+        elif self.global_state.has_key(addr):
+            self.global_state.set_variable(addr, new_value)
+        else:
+            print "[ERROR]: Unknown variable. Exiting."
+            error_str = rffi.charp2str(llwrap.LLVMPrintValueToString(var))
+            raise NoSuchVariableException(error_str)
 
 class State(object):
     ''' Represents the state of a stack frame or of the entire program. '''
@@ -36,7 +91,4 @@ class State(object):
         ''' Checks if a given key exists in the dictionary. '''
 
         off = self.var_offsets.get(name, -1)
-        if off == -1:
-            return False
-        return True
-
+        return off != -1


### PR DESCRIPTION
This branch contains a slightly improved version of the interpreter:
- each type of instruction corresponds to a subclass of `W_BaseInstruction` (instead of checking the instruction opcode in the main loop of the interpreter and performing the appropriate operations, the result of an instruction is obtained by calling its `execute` method)
- there are a couple of new tests (the old tests are too long and will need to be refactored as well)
